### PR TITLE
Discuss "black box rule" and robust cancellation separately?

### DIFF
--- a/StructuredConcurrency.md
+++ b/StructuredConcurrency.md
@@ -33,7 +33,7 @@ See, for example,
 [section 2.1.2](https://books.google.com.au/books?redir_esc=y&id=J5-ckoCgc3IC&q=paralleism+versus+concurrency#v=snippet&q=paralleism%20versus%20concurrency&f=false)
 of "Introduction to Concurrency in Programming Languages".
 
-### What is structured concurrency?
+### The black box rule
 
 To quote the [`libdill` documentation](http://libdill.org/structured-concurrency.html),
 


### PR DESCRIPTION
(I'm just opening a PR just for commenting on your notes)

I think it might be better to emphasize that structured concurrency has a few sub-concepts.

My understanding is that what njs calls [_"black box rule"_](https://vorpus.org/blog/notes-on-structured-concurrency-or-go-statement-considered-harmful/#what-happened-to-goto) is a sub-concept of structured concurrency and it's more fundamental than robust cancellation.  So, I'd suggest to introduce "black box rule" and cancellation as different sub-concepts from the get-go.  I think this is particularly important in Julia because many compute-intensive task don't need cancellation and people may not want to have runtime and conceptual overhead of robust cancellation.  An alternative term may be [_call tree_](http://250bpm.com/blog:124).

One counter-example to my argument that "black box rule" is more fundamental is Go's `errgroup` and `context`.  `errgroup` is the implementation of the "black box rule" while `context` is the implementation of robust cancellation.  `errgroup` is implemented on top of `context` and it may contradict with my argument that "black box rule" (`errgroup`) is more fundamental than robust cancellation (`errgroup`).  But I think the fact that they are implemented in separate packages in Go at least backs up my argument that those are different concepts.

So, maybe it is a good idea to organize the sections like this?

* Structured Concurrency
    * Background terminology
    * The black box rule
    * Robust task cancellation
    * ...
