### PR TITLE
Are go statements harmful?

### DIFF
--- a/StructuredConcurrency.md
+++ b/StructuredConcurrency.md
@@ -81,6 +81,10 @@ function boundaries is the major feature of modern languages, the _absence_ of
 "go statement" (`@spawn` in Julia 1.3) is the major feature of the structured
 concurrency.  This is because it is impossible for caller to know that a
 function follows structured concurrency without the language-level guarantee.
+Note that the situation in Julia is more serious compared to other languages
+which has functions with "two-colors" (see below) and plugable eventloop (e.g.,
+Python) where it is possible to enforce the _absence_ of "go statement" at the
+library level.
 
 ### Structured concurrency in Julia 1.0?
 

--- a/StructuredConcurrency.md
+++ b/StructuredConcurrency.md
@@ -76,6 +76,11 @@ has expressed it this way in his blog post [Notes on structured concurrency or,
 > propagation. Therefore, like goto, they have no place in a modern high-level
 > language.
 
+It is important to emphasize that, as _absence_ of goto statement that can cross
+function boundaries is the major feature of modern languages, the _absence_ of
+"go statement" (`@spawn` in Julia 1.3) is the major feature of the structured
+concurrency.  This is because it is impossible for caller to know that a
+function follows structured concurrency without the language-level guarantee.
 
 ### Structured concurrency in Julia 1.0?
 


### PR DESCRIPTION
OK... I think this can be very controversial.  But I suggest to add:

> It is important to emphasize that, as _absence_ of goto statement that can cross function boundaries is the major feature of modern languages, the _absence_ of "go statement" (`@spawn` in Julia 1.3) is the major feature of the structured concurrency.  This is because it is impossible for caller to know that a function follows structured concurrency without the language-level guarantee.

To emphasize that it has large impact in Julia than (say) Python, I also added:

> Note that the situation in Julia is more serious compared to other languages which has functions with "two-colors" (see below) and plugable eventloop (e.g., Python) where it is possible to enforce the _absence_ of "go statement" at the library level.
